### PR TITLE
Allow value and label to differ

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,67 @@
+{
+    "predef"        : [         // Extra globals.
+      "require", "module", "exports"
+    ],
+    "maxerr"        : 100,      // Maximum errors before stopping.
+    "bitwise"       : true,     // Prohibit bitwise operators (&, |, ^, etc.).
+    "eqeqeq"        : true,     // Require triple equals i.e. `===`.
+    "es3"           : true,     // Warn about trailing comma on final item of object literal
+    "immed"         : true,     // Require immediate invocations to be wrapped in parens e.g. `( function(){}() );`
+    "latedef"       : true,     // Prohibit variable use before definition.
+    "newcap"        : false,    // Require capitalization of all constructor functions e.g. `new F()`.
+    "noarg"         : true,     // Prohibit use of `arguments.caller` and `arguments.callee`.
+    "noempty"       : true,     // Prohibit use of empty blocks.
+    "nonew"         : true,     // Prohibit use of constructors for side-effects.
+    "plusplus"      : true,     // Prohibit use of `++` & `--`.
+    "regexp"        : true,     // Prohibit `.` and `[^...]` in regular expressions.
+    "undef"         : true,     // Require all non-global variables be declared before they are used.
+    "strict"        : true,     // Require `use strict` pragma in every file.
+    "globalstrict"  : true,     // Allow global "use strict" (also enables 'strict').
+    "trailing"      : false,    // Prohibit trailing whitespaces. Disabled because of JSX
+    "quotmark"      : false,    // Require single quotes. Disabled because of JSX
+    "unused"        : "vars",   // Warns when you define and never use your variables
+    "maxdepth"      : 3,        // Warn about nesting depth
+    "eqnull"        : true,     // Tolerate use of `== null`.
+
+    // == Relaxing Options ================================================
+    //
+    // These options allow you to suppress certain types of warnings. Use
+    // them only if you are absolutely positive that you know what you are
+    // doing.
+    "forin"         : false,    // Tolerate `for in` loops without `hasOwnPrototype`.
+    "curly"         : false,    // Require {} for every new block or scope.
+    "asi"           : false,    // Tolerate Automatic Semicolon Insertion (no semicolons).
+    "boss"          : false,    // Tolerate assignments inside if, for & while. Usually conditions & loops are for comparison, not assignments.
+    "debug"         : false,    // Allow debugger statements e.g. browser breakpoints.
+    "es5"           : false,    // Allow EcmaScript 5 syntax.
+    "esnext"        : false,    // Allow ES.next specific features such as `const` and `let`.
+    "evil"          : false,    // Tolerate use of `eval`.
+    "expr"          : false,    // Tolerate `ExpressionStatement` as Programs.
+    "funcscope"     : false,    // Tolerate declarations of variables inside of control structures while accessing them later from the outside.
+    "iterator"      : false,    // Allow usage of __iterator__ property.
+    "lastsemic"     : false,    // Tolerat missing semicolons when the it is omitted for the last statement in a one-line block.
+    "laxbreak"      : false,    // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
+    "laxcomma"      : false,    // Suppress warnings about comma-first coding style.
+    "loopfunc"      : false,    // Allow functions to be defined within loops.
+    "multistr"      : false,    // Tolerate multi-line strings.
+    "onecase"       : false,    // Tolerate switches with just one case.
+    "proto"         : false,    // Tolerate __proto__ property. This property is deprecated.
+    "regexdash"     : false,    // Tolerate unescaped last dash i.e. `[-...]`.
+    "scripturl"     : false,    // Tolerate script-targeted URLs.
+    "smarttabs"     : false,    // Tolerate mixed tabs and spaces when the latter are used for alignmnent only.
+    "shadow"        : false,    // Allows re-define variables later in code e.g. `var x=1; x=2;`.
+    "sub"           : false,    // Tolerate all forms of subscript notation besides dot notation e.g. `dict['key']` instead of `dict.key`.
+    "supernew"      : false,    // Tolerate `new function () { ... };` and `new Object;`.
+    "validthis"     : false,    // Tolerate strict violations when the code is running in strict mode and you use this in a non-constructor function.
+    "browser"       : true,    // Standard browser globals e.g. `window`, `document`.
+    "couch"         : false,    // Enable globals exposed by CouchDB.
+    "devel"         : true,    // Allow development statements e.g. `console.log();`.
+    "dojo"          : false,    // Enable globals exposed by Dojo Toolkit.
+    "jquery"        : false,    // Enable globals exposed by jQuery JavaScript library.
+    "mootools"      : false,    // Enable globals exposed by MooTools JavaScript framework.
+    "node"          : false,    // Enable globals available when code is running inside of the NodeJS runtime environment.
+    "nonstandard"   : false,    // Define non-standard but widely adopted globals such as escape and unescape.
+    "prototypejs"   : false,    // Enable globals exposed by Prototype JavaScript framework.
+    "rhino"         : false,    // Enable globals available when your code is running inside of the Rhino runtime environment.
+    "wsh"           : false    // Enable globals available when your code is running as a script for the Windows Script Host.
+}

--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -72,7 +72,7 @@ var AutocompleteDemo = React.createClass({
                 <Autocomplete
                     className                   = {'demo__autocomplete'}
                     id                          = {'autocompleteDemo'}
-                    searchField                 = {'option'}
+                    labelField                  = {'option'}
                     options                     = {autocompleteOptions}
                     placeholder                 = {'What\'s your favorite fruit?'}
                     minimumCharacters           = {0}

--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -251,8 +251,6 @@ var ReactAutocomplete = React.createClass({
     },
 
     makeSelection: function makeSelection(selection) {
-        var inputDOMNode = React.findDOMNode(this.refs.inputComponent.refs.input);
-
         this.setState({
             suggestions: [],
             selection: selection,
@@ -266,8 +264,6 @@ var ReactAutocomplete = React.createClass({
         if (this.props.makeSelection) {
             this.props.makeSelection(selection);
         }
-
-        inputDOMNode.blur();
     },
 
     dropdownVisible: function dropdownVisible() {

--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -282,11 +282,11 @@ var ReactAutocomplete = React.createClass({
         this.setState(state);
 
         if (this.props.onBlur) {
-            this.props.onBlur(value);
+            this.props.onBlur(e);
         }
     },
 
-    handleFocus: function handleFocus() {
+    handleFocus: function handleFocus(e) {
         if (this.state.searchQuery === '' && !this.state.selection && this.props.showSuggestionsOnEmptyFocus === true) {
             this.setState({
                 suggestions: this.props.options,
@@ -295,7 +295,7 @@ var ReactAutocomplete = React.createClass({
         }
 
         if (this.props.onFocus) {
-            this.props.onFocus(value);
+            this.props.onFocus(e);
         }
     },
 

--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -6,7 +6,6 @@ var React = require('react');
 var classNames = require('classnames');
 var TextInput = require('synfrastructure').Input;
 var Fuse = require('fuse.js');
-var ScrollListenerMixin = require('react-scroll-components').ScrollListenerMixin;
 
 var KC_ENTER = 13,
     KC_ESC = 27,
@@ -42,6 +41,7 @@ var ReactAutocomplete = React.createClass({
         dropdownPosition: React.PropTypes.oneOf(['top', 'bottom']),
         dropdownHeight: React.PropTypes.number,
         InputComponent: React.PropTypes.any,
+        inputProps: React.PropTypes.object,
         className: React.PropTypes.string
     },
 
@@ -69,6 +69,7 @@ var ReactAutocomplete = React.createClass({
             dropdownPosition: null,
             dropdownHeight: null,
             InputComponent: TextInput,
+            inputProps: {},
             className: null
         };
     },
@@ -350,20 +351,22 @@ var ReactAutocomplete = React.createClass({
             componentPosition = React.findDOMNode(this.refs.autocomplete).getBoundingClientRect().top,
             dropdownPosition = componentPosition + offset > winHeight ? 'top' : 'bottom';
 
-        if (!this.props.dropdownPosition && this.state.dropdownPosition != dropdownPosition) {
+        if (!this.props.dropdownPosition && this.state.dropdownPosition !== dropdownPosition) {
             this.setState({ dropdownPosition: dropdownPosition });
         }
     },
 
     renderInput: function renderInput() {
-        var value = this.props.value,
-            Component = this.props.InputComponent;
+        var props, value, Component;
+
+        value = this.props.value;
+        Component = this.props.InputComponent;
 
         if (!value) {
             value = this.state.selection ? this.state.selection[this.props.searchField] : this.state.searchQuery;
         }
 
-        return React.createElement(Component, {
+        props = {
             ref: 'inputComponent',
             className: 'autocomplete__input',
             id: this.props.id,
@@ -376,7 +379,11 @@ var ReactAutocomplete = React.createClass({
             placeholder: this.props.placeholder,
             autoComplete: false,
             type: 'text'
-        });
+        };
+
+        _.extend(props, this.props.inputProps);
+
+        return React.createElement(Component, props);
     },
 
     renderDropdownItems: function renderDropdownItems() {

--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -107,7 +107,7 @@ var ReactAutocomplete = React.createClass({
             }
         }
 
-        return null;
+        return value;
     },
 
     // Get options with translated labels, if translation function is set
@@ -154,21 +154,10 @@ var ReactAutocomplete = React.createClass({
     },
 
     componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
-        var state = {
-            dropdownIndex: 0,
-            fuse: this.createFuseObject(nextProps.options, nextProps.labelField)
-        };
-
-        if (nextProps.value) {
-            state.searchQuery = this.getDisplayValue(nextProps.value);
-        }
-
         // Reset lazily-loaded options property if options have changed
         if (!_(this.props.options).isEqual(nextProps.options)) {
             this.options = null;
         }
-
-        this.setState(state);
     },
 
     componentDidUpdate: function componentDidUpdate(prevProps, prevState) {
@@ -421,12 +410,7 @@ var ReactAutocomplete = React.createClass({
     renderInput: function renderInput() {
         var props, value, Component;
 
-        value = this.getDisplayValue(this.props.value);
-        Component = this.props.InputComponent;
-
-        if (!value) {
-            value = this.state.selection ? this.state.selection[this.props.labelField] : this.state.searchQuery;
-        }
+        value = this.state.selection ? this.state.selection[this.props.labelField] : this.state.searchQuery;
 
         props = {
             ref: 'inputComponent',
@@ -442,6 +426,7 @@ var ReactAutocomplete = React.createClass({
             type: 'text'
         };
 
+        Component = this.props.InputComponent;
         _.extend(props, this.props.inputProps);
 
         return React.createElement(Component, props);

--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -28,6 +28,8 @@ var ReactAutocomplete = React.createClass({
         id: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]).isRequired,
         makeSelection: React.PropTypes.func,
         onChange: React.PropTypes.func,
+        onBlur: React.PropTypes.func,
+        onFocus: React.PropTypes.func,
         options: React.PropTypes.arrayOf(React.PropTypes.object),
         initialValue: React.PropTypes.object,
         minimumCharacters: React.PropTypes.number,
@@ -278,6 +280,10 @@ var ReactAutocomplete = React.createClass({
         }
 
         this.setState(state);
+
+        if (this.props.onBlur) {
+            this.props.onBlur(value);
+        }
     },
 
     handleFocus: function handleFocus() {
@@ -286,6 +292,10 @@ var ReactAutocomplete = React.createClass({
                 suggestions: this.props.options,
                 dropdownIndex: 0
             });
+        }
+
+        if (this.props.onFocus) {
+            this.props.onFocus(value);
         }
     },
 

--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -37,7 +37,6 @@ var ReactAutocomplete = React.createClass({
         maximumCharacters: React.PropTypes.number,
         maximumSuggestions: React.PropTypes.number,
         placeholder: React.PropTypes.string,
-        clearOnSelect: React.PropTypes.bool,
         clearOnFocus: React.PropTypes.bool,
         retainValueOnBlur: React.PropTypes.bool,
         showSuggestionsOnEmptyFocus: React.PropTypes.bool,
@@ -70,7 +69,6 @@ var ReactAutocomplete = React.createClass({
             maximumSuggestions: 5,
             placeholder: '',
             retainValueOnBlur: false,
-            clearOnSelect: false,
             showSuggestionsOnEmptyFocus: false,
             dropdownPosition: null,
             dropdownHeight: null,
@@ -212,19 +210,11 @@ var ReactAutocomplete = React.createClass({
     makeSelection: function makeSelection(selection) {
         var inputDOMNode = React.findDOMNode(this.refs.inputComponent.refs.input);
 
-        if (this.props.clearOnSelect) {
-            this.setState({
-                suggestions: [],
-                selection: null,
-                searchQuery: ''
-            });
-        } else {
-            this.setState({
-                suggestions: [],
-                selection: selection,
-                searchQuery: selection[this.props.labelField]
-            });
-        }
+        this.setState({
+            suggestions: [],
+            selection: selection,
+            searchQuery: selection[this.props.labelField]
+        });
 
         if (this.props.onChange) {
             this.props.onChange(selection[this.props.valueField]);

--- a/src/autocomplete.jsx
+++ b/src/autocomplete.jsx
@@ -280,8 +280,6 @@ var ReactAutocomplete = React.createClass({
 
     makeSelection(selection)
     {
-        var inputDOMNode = React.findDOMNode(this.refs.inputComponent.refs.input);
-
         this.setState({
             suggestions : [],
             selection   : selection,
@@ -295,8 +293,6 @@ var ReactAutocomplete = React.createClass({
         if (this.props.makeSelection) {
             this.props.makeSelection(selection);
         }
-
-        inputDOMNode.blur();
     },
 
     dropdownVisible()

--- a/src/autocomplete.jsx
+++ b/src/autocomplete.jsx
@@ -31,6 +31,8 @@ var ReactAutocomplete = React.createClass({
         ]).isRequired,
         makeSelection               : React.PropTypes.func,
         onChange                    : React.PropTypes.func,
+        onBlur                      : React.PropTypes.func,
+        onFocus                     : React.PropTypes.func,
         options                     : React.PropTypes.arrayOf(React.PropTypes.object),
         initialValue                : React.PropTypes.object,
         minimumCharacters           : React.PropTypes.number,
@@ -313,6 +315,10 @@ var ReactAutocomplete = React.createClass({
         }
 
         this.setState(state);
+
+        if (this.props.onBlur) {
+            this.props.onBlur(value);
+        }
     },
 
     handleFocus()
@@ -322,6 +328,10 @@ var ReactAutocomplete = React.createClass({
                 suggestions   : this.props.options,
                 dropdownIndex : 0
             });
+        }
+
+        if (this.props.onFocus) {
+            this.props.onFocus(value);
         }
     },
 

--- a/src/autocomplete.jsx
+++ b/src/autocomplete.jsx
@@ -24,7 +24,7 @@ var ReactAutocomplete = React.createClass({
     propTypes : {
         // makeSelection is responsible for responding when a user selects a suggested item
         // options is list of objects
-        labelField                  : React.PropTypes.string.isRequired,
+        labelField                  : React.PropTypes.string,
         id                          : React.PropTypes.oneOfType([
             React.PropTypes.string,
             React.PropTypes.number
@@ -60,6 +60,7 @@ var ReactAutocomplete = React.createClass({
     getDefaultProps()
     {
         return {
+            labelField                  : 'label',
             makeSelection               : null,
             onChange                    : null,
             options                     : null,

--- a/src/autocomplete.jsx
+++ b/src/autocomplete.jsx
@@ -112,7 +112,7 @@ var ReactAutocomplete = React.createClass({
             }
         }
 
-        return null;
+        return value;
     },
 
     // Get options with translated labels, if translation function is set
@@ -170,21 +170,10 @@ var ReactAutocomplete = React.createClass({
 
     componentWillReceiveProps(nextProps)
     {
-        var state = {
-            dropdownIndex : 0,
-            fuse          : this.createFuseObject(nextProps.options, nextProps.labelField)
-        };
-
-        if (nextProps.value) {
-            state.searchQuery = this.getDisplayValue(nextProps.value);
-        }
-
         // Reset lazily-loaded options property if options have changed
         if (! _(this.props.options).isEqual(nextProps.options)) {
             this.options = null;
         }
-
-        this.setState(state);
     },
 
     componentDidUpdate(prevProps, prevState)
@@ -465,12 +454,9 @@ var ReactAutocomplete = React.createClass({
     {
         var props, value, Component;
 
-        value     = this.getDisplayValue(this.props.value);
-        Component = this.props.InputComponent;
-
-        if (! value) {
-            value = this.state.selection ? this.state.selection[this.props.labelField] : this.state.searchQuery;
-        }
+        value = this.state.selection ?
+            this.state.selection[this.props.labelField] :
+            this.state.searchQuery;
 
         props = {
             ref          : 'inputComponent',
@@ -486,6 +472,7 @@ var ReactAutocomplete = React.createClass({
             type         : 'text'
         };
 
+        Component = this.props.InputComponent;
         _.extend(props, this.props.inputProps);
 
         return React.createElement(Component, props);

--- a/src/autocomplete.jsx
+++ b/src/autocomplete.jsx
@@ -1,12 +1,11 @@
 'use strict';
 
-var win                 = typeof window !== 'undefined' ? window : false;
-var _                   = require('lodash');
-var React               = require('react');
-var classNames          = require('classnames');
-var TextInput           = require('synfrastructure').Input;
-var Fuse                = require('fuse.js');
-var ScrollListenerMixin = require('react-scroll-components').ScrollListenerMixin;
+var win        = typeof window !== 'undefined' ? window : false;
+var _          = require('lodash');
+var React      = require('react');
+var classNames = require('classnames');
+var TextInput  = require('synfrastructure').Input;
+var Fuse       = require('fuse.js');
 
 var KC_ENTER     = 13,
     KC_ESC       = 27,
@@ -45,6 +44,7 @@ var ReactAutocomplete = React.createClass({
         dropdownPosition            : React.PropTypes.oneOf(['top', 'bottom']),
         dropdownHeight              : React.PropTypes.number,
         InputComponent              : React.PropTypes.any,
+        inputProps                  : React.PropTypes.object,
         className                   : React.PropTypes.string
     },
 
@@ -73,6 +73,7 @@ var ReactAutocomplete = React.createClass({
             dropdownPosition            : null,
             dropdownHeight              : null,
             InputComponent              : TextInput,
+            inputProps                  : {},
             className                   : null
         };
     },
@@ -391,7 +392,7 @@ var ReactAutocomplete = React.createClass({
 
         if (
             ! this.props.dropdownPosition &&
-            this.state.dropdownPosition != dropdownPosition
+            this.state.dropdownPosition !== dropdownPosition
         ) {
             this.setState({dropdownPosition : dropdownPosition});
         }
@@ -399,29 +400,33 @@ var ReactAutocomplete = React.createClass({
 
     renderInput()
     {
-        var value     = this.props.value,
-            Component = this.props.InputComponent;
+        var props, value, Component;
+
+        value     = this.props.value;
+        Component = this.props.InputComponent;
 
         if (! value) {
             value = this.state.selection ? this.state.selection[this.props.searchField] : this.state.searchQuery;
         }
 
-        return (
-            <Component
-                ref          = 'inputComponent'
-                className    = 'autocomplete__input'
-                id           = {this.props.id}
-                onKeyDown    = {this.handleKeyDown}
-                onChange     = {this.handleChange}
-                onBlur       = {this.handleBlur}
-                onFocus      = {this.handleFocus}
-                initialValue = {null}
-                value        = {value}
-                placeholder  = {this.props.placeholder}
-                autoComplete = {false}
-                type         = 'text'
-            />
-        );
+        props = {
+            ref          : 'inputComponent',
+            className    : 'autocomplete__input',
+            id           : this.props.id,
+            onKeyDown    : this.handleKeyDown,
+            onChange     : this.handleChange,
+            onBlur       : this.handleBlur,
+            onFocus      : this.handleFocus,
+            initialValue : null,
+            value        : value,
+            placeholder  : this.props.placeholder,
+            autoComplete : false,
+            type         : 'text'
+        };
+
+        _.extend(props, this.props.inputProps);
+
+        return React.createElement(Component, props);
     },
 
     renderDropdownItems()

--- a/src/autocomplete.jsx
+++ b/src/autocomplete.jsx
@@ -317,11 +317,11 @@ var ReactAutocomplete = React.createClass({
         this.setState(state);
 
         if (this.props.onBlur) {
-            this.props.onBlur(value);
+            this.props.onBlur(e);
         }
     },
 
-    handleFocus()
+    handleFocus(e)
     {
         if (this.state.searchQuery === '' && ! this.state.selection && this.props.showSuggestionsOnEmptyFocus === true) {
             this.setState({
@@ -331,7 +331,7 @@ var ReactAutocomplete = React.createClass({
         }
 
         if (this.props.onFocus) {
-            this.props.onFocus(value);
+            this.props.onFocus(e);
         }
     },
 

--- a/src/autocomplete.jsx
+++ b/src/autocomplete.jsx
@@ -25,6 +25,7 @@ var ReactAutocomplete = React.createClass({
         // makeSelection is responsible for responding when a user selects a suggested item
         // options is list of objects
         labelField                  : React.PropTypes.string,
+        valueField                  : React.PropTypes.string,
         id                          : React.PropTypes.oneOfType([
             React.PropTypes.string,
             React.PropTypes.number
@@ -40,6 +41,7 @@ var ReactAutocomplete = React.createClass({
         maximumSuggestions          : React.PropTypes.number,
         placeholder                 : React.PropTypes.string,
         clearOnSelect               : React.PropTypes.bool,
+        clearOnFocus                : React.PropTypes.bool,
         retainValueOnBlur           : React.PropTypes.bool,
         showSuggestionsOnEmptyFocus : React.PropTypes.bool,
         value                       : React.PropTypes.string, // Value to display in text box
@@ -61,6 +63,7 @@ var ReactAutocomplete = React.createClass({
     {
         return {
             labelField                  : 'label',
+            valueField                  : 'value',
             makeSelection               : null,
             onChange                    : null,
             options                     : null,
@@ -252,7 +255,7 @@ var ReactAutocomplete = React.createClass({
         }
 
         if (this.props.onChange) {
-            this.props.onChange(selection[this.props.labelField]);
+            this.props.onChange(selection[this.props.valueField]);
         }
 
         if (this.props.makeSelection) {
@@ -324,8 +327,9 @@ var ReactAutocomplete = React.createClass({
 
     handleFocus(e)
     {
-        if (this.state.searchQuery === '' && ! this.state.selection && this.props.showSuggestionsOnEmptyFocus === true) {
+        if (this.props.clearOnFocus && ! this.state.selection && this.props.showSuggestionsOnEmptyFocus === true) {
             this.setState({
+                searchQuery   : '',
                 suggestions   : this.props.options,
                 dropdownIndex : 0
             });
@@ -342,8 +346,18 @@ var ReactAutocomplete = React.createClass({
      *
      * @param  Event event
      */
-    handleKeyDown(value, event)
+    handleKeyDown()
     {
+        var event;
+
+        // The default InputComponent includes the current value as the first arg and the event as the second.
+        // If InputComponent is overridden, this value will likely not be included.
+        if (_(arguments[0]).isObject()) {
+            event = arguments[0];
+        } else {
+            event = arguments[1];
+        }
+
         event.stopPropagation();
 
         var code = event.keyCode ? event.keyCode : event.which;

--- a/src/autocomplete.jsx
+++ b/src/autocomplete.jsx
@@ -40,7 +40,6 @@ var ReactAutocomplete = React.createClass({
         maximumCharacters           : React.PropTypes.number,
         maximumSuggestions          : React.PropTypes.number,
         placeholder                 : React.PropTypes.string,
-        clearOnSelect               : React.PropTypes.bool,
         clearOnFocus                : React.PropTypes.bool,
         retainValueOnBlur           : React.PropTypes.bool,
         showSuggestionsOnEmptyFocus : React.PropTypes.bool,
@@ -74,7 +73,6 @@ var ReactAutocomplete = React.createClass({
             maximumSuggestions          : 5,
             placeholder                 : '',
             retainValueOnBlur           : false,
-            clearOnSelect               : false,
             showSuggestionsOnEmptyFocus : false,
             dropdownPosition            : null,
             dropdownHeight              : null,
@@ -240,19 +238,11 @@ var ReactAutocomplete = React.createClass({
     {
         var inputDOMNode = React.findDOMNode(this.refs.inputComponent.refs.input);
 
-        if (this.props.clearOnSelect) {
-            this.setState({
-                suggestions : [],
-                selection   : null,
-                searchQuery : ''
-            });
-        } else {
-            this.setState({
-                suggestions : [],
-                selection   : selection,
-                searchQuery : selection[this.props.labelField]
-            });
-        }
+        this.setState({
+            suggestions : [],
+            selection   : selection,
+            searchQuery : selection[this.props.labelField]
+        });
 
         if (this.props.onChange) {
             this.props.onChange(selection[this.props.valueField]);

--- a/src/autocomplete.jsx
+++ b/src/autocomplete.jsx
@@ -24,7 +24,7 @@ var ReactAutocomplete = React.createClass({
     propTypes : {
         // makeSelection is responsible for responding when a user selects a suggested item
         // options is list of objects
-        searchField                 : React.PropTypes.string.isRequired,
+        labelField                  : React.PropTypes.string.isRequired,
         id                          : React.PropTypes.oneOfType([
             React.PropTypes.string,
             React.PropTypes.number
@@ -86,7 +86,7 @@ var ReactAutocomplete = React.createClass({
 
         return {
             dropdownIndex    : 0,
-            fuse             : this.createFuseObject(this.props.options, this.props.searchField),
+            fuse             : this.createFuseObject(this.props.options, this.props.labelField),
             suggestions      : [],
             selection        : selection || null,
             searchQuery      : this.props.value || '',
@@ -131,7 +131,7 @@ var ReactAutocomplete = React.createClass({
     {
         var state = {
             dropdownIndex : 0,
-            fuse          : this.createFuseObject(nextProps.options, nextProps.searchField)
+            fuse          : this.createFuseObject(nextProps.options, nextProps.labelField)
         };
 
         if (nextProps.value) {
@@ -146,7 +146,7 @@ var ReactAutocomplete = React.createClass({
         this.setDropdownPosition();
     },
 
-    createFuseObject(items, searchField)
+    createFuseObject(items, labelField)
     {
         var options = {
             caseSensitive    : false,
@@ -154,7 +154,7 @@ var ReactAutocomplete = React.createClass({
             shouldSort       : true,
             threshold        : 0.35,
             maxPatternLength : this.props.maximumCharacters,
-            keys             : [searchField]
+            keys             : [labelField]
         };
 
         return new Fuse(items, options);
@@ -246,12 +246,12 @@ var ReactAutocomplete = React.createClass({
             this.setState({
                 suggestions : [],
                 selection   : selection,
-                searchQuery : selection[this.props.searchField]
+                searchQuery : selection[this.props.labelField]
             });
         }
 
         if (this.props.onChange) {
-            this.props.onChange(selection[this.props.searchField]);
+            this.props.onChange(selection[this.props.labelField]);
         }
 
         if (this.props.makeSelection) {
@@ -416,7 +416,7 @@ var ReactAutocomplete = React.createClass({
         Component = this.props.InputComponent;
 
         if (! value) {
-            value = this.state.selection ? this.state.selection[this.props.searchField] : this.state.searchQuery;
+            value = this.state.selection ? this.state.selection[this.props.labelField] : this.state.searchQuery;
         }
 
         props = {
@@ -453,9 +453,9 @@ var ReactAutocomplete = React.createClass({
                 <li
                     className   = {classes}
                     onMouseDown = {_.partial(component.makeSelection, suggestion)}
-                    key         = {suggestion[component.props.searchField]}
+                    key         = {suggestion[component.props.labelField]}
                 >
-                    {suggestion[component.props.searchField]}
+                    {suggestion[component.props.labelField]}
                 </li>
             );
         });


### PR DESCRIPTION
### Acceptance Criteria
- Forms with different labels and values will work (will reference this issue in a PR that uses it).
### Tasks
1. Replace `searchField` prop with `labelField` and `valueField`. They define which keys to find the labels and values in the `options` prop.  
2. ~~Add `labelPassthrough` prop, which we can pass the `t` function if we need to run labels through translation.~~ Looks trickier than I thought. We'll just need to pass pre-translated strings to it.
3. In `onChange` map the value in the input field with the value that goes with that label.
### Additional Notes
- {{list additional notes here, remove if not applicable}}
